### PR TITLE
Correcting case in rate limit headers

### DIFF
--- a/source/includes/harvest/_introduction.md
+++ b/source/includes/harvest/_introduction.md
@@ -79,11 +79,11 @@ If you're making test API requests with cURL you can use the `-u` flag to set th
 
 ```
 Status: 200 OK
-X-RateLimit-Limit: 50
-X-RateLimit-Remaining: 49
+X-Ratelimit-Limit: 50
+X-Ratelimit-Remaining: 49
 ```
 
-API requests are limited to 50 calls per 10 seconds, though that limit is subject to change. Exceeding that limit will cause Harvest to return an `HTTP 429` response. Check the `X-RateLimit-Limit` and `X-RateLimit-Remaining` headers to see how many more requests you are allowed until throttling kicks in.
+API requests are limited to 50 calls per 10 seconds, though that limit is subject to change. Exceeding that limit will cause Harvest to return an `HTTP 429` response. Check the `X-Ratelimit-Limit` and `X-Ratelimit-Remaining` headers to see how many more requests you are allowed until throttling kicks in.
 
 ## Pagination
 


### PR DESCRIPTION
For reference, header looks like the one below:
{Status=200 OK, X-Ratelimit-Limit=40, Server=Cowboy, X-Ratelimit-Remaining=39, X-Content-Type-Options=nosniff, Connection=keep-alive, Content-Length=3829, Date=Sat, 30 Jul 2016 06:05:54 GMT, Link=<https://harvest.greenhouse.io/v1/offers?page=1&per_page=500>; rel="last", Content-Type=application/json;charset=utf-8, Via=1.1 vegur}