### PR TITLE
GET request instead of POST (list_tests)

### DIFF
--- a/source/includes/assessment/_list_tests.md
+++ b/source/includes/assessment/_list_tests.md
@@ -5,7 +5,7 @@ Greenhouse will first need to retreive the list of tests from the Assessment Par
 `GET https://www.testing-partner.com/api/list_tests`
 
 ```shell
-curl -X POST 'https://www.testing-partner.com/api/list_tests'
+curl 'https://www.testing-partner.com/api/list_tests'
 -H "Authorization: Basic MGQwMzFkODIyN2VhZmE2MWRjMzc1YTZjMmUwNjdlMjQ6"
 ```
 


### PR DESCRIPTION
According to the documentation for the `list_tests` endpoint, it's a `GET` request, not a `POST`.