### PR TITLE
Removes a merge conflict from the API Harvest docs

### DIFF
--- a/source/includes/harvest/_candidates.md
+++ b/source/includes/harvest/_candidates.md
@@ -766,5 +766,4 @@ On-Behalf-Of | ID of the user issuing this request. Required for auditing purpos
 
 Parameter | Required | Type | Description
 --------- | ----------- | ----------- | -----------
-<<<<<<< HEAD
 fields | Yes | comma-delimited string | The set of field names that should be anonymized on the candidate from the following list: full_name, current_company, current_title, tags, phone_numbers, emails, social_media_links, websites, addresses, location, custom_candidate_fields, source, recruiter, coordinator, attachments, application_questions, referral_questions, notes, rejection_notes, email_addresses, activity_items, innotes, inmails, rejection_reason, scorecards_and_interviews, offers, credited_to, headline, all_offer_versions, and follow_up_reminders.


### PR DESCRIPTION
There's a stray `<<< HEAD` comment that needs to be removed from our API docs.