### PR TITLE
Fixed documentation regarding the Job Application Submission

### DIFF
--- a/source/includes/job-board/_applications.md
+++ b/source/includes/job-board/_applications.md
@@ -64,7 +64,7 @@ curl -X POST \
   -F "question_12349_url_filename=attachment.pdf" \
   -F "question_12350_content=SGVsbG8sIHdvcmxkIQo=" \
   -F "question_12350_content_filename=something_else.txt" \
-  "https://api.greenhouse.io/v1/applications"
+  "https://api.greenhouse.io/v1/boards/very_awesome_inc/jobs/127817"
 ```
 
 > or, you can POST a JSON encoded body (with `Content-Type: application/json`):
@@ -113,7 +113,7 @@ curl -X POST \
     ],
     "mapped_url_token":"token12345"
   }' \
-  "https://api.greenhouse.io/v1/applications"
+  "https://api.greenhouse.io/v1/boards/very_awesome_inc/jobs/127817"
 ```
 
 Use this endpoint to submit a new application. This endpoint accepts a multipart form POST representing a job application. Application forms are job-specific and will be constructed via the "questions" array available via the [Job method](#retrieve-a-job). Please see the [Job method](#retrieve-a-job) documentation for instructions on submitting location information through the API.
@@ -130,7 +130,7 @@ Note that when submitting an application through this method, Greenhouse will no
 
 ### HTTP Request
 
-`POST https://api.greenhouse.io/v1/applications`
+`POST https://api.greenhouse.io/v1/boards/{board_token}/jobs/{id}`
 
 ### Request Headers
 

--- a/source/includes/job-board/_applications.md
+++ b/source/includes/job-board/_applications.md
@@ -132,11 +132,16 @@ Note that when submitting an application through this method, Greenhouse will no
 
 `POST https://api.greenhouse.io/v1/boards/{board_token}/jobs/{id}`
 
+Parameter | Description
+ --------- | -----------
+ board_token | Job Board URL token.  If you're submitting an application for a job post on an internal job board, use `"internal"`.
+ id | Job post ID. Both internal and external job posts are allowed.
+
 ### Request Headers
 
 Parameter | Description
 --------- | -----------
-Authorization | This header should include a basic authorization with a Base64 encoded API token
+Authorization | This header should include a basic authorization with a **Base64 encoded** API token
 
 ### Request Parameters
 

--- a/source/includes/job-board/_applications.md
+++ b/source/includes/job-board/_applications.md
@@ -116,7 +116,7 @@ curl -X POST \
   "https://api.greenhouse.io/v1/boards/very_awesome_inc/jobs/127817"
 ```
 
-Use this endpoint to submit a new application. This endpoint accepts a multipart form POST representing a job application. Application forms are job-specific and will be constrcuted via the "questions" array available via the [Job method](#retrieve-a-job). Please see the [Job method](#retrieve-a-job) documentation for instructions on submitting location information through the API.
+Use this endpoint to submit a new application. This endpoint accepts a multipart form POST representing a job application. Application forms are job-specific and will be constructed via the "questions" array available via the [Job method](#retrieve-a-job). Please see the [Job method](#retrieve-a-job) documentation for instructions on submitting location information through the API.
 
 Note that when submitting an application through this method, Greenhouse will not confirm the inclusion of required fields. Validation for required fields must be done on the client side, as Greenhouse will not reject applications that are missing required fields.
 
@@ -125,7 +125,7 @@ Note that when submitting an application through this method, Greenhouse will no
 </aside>
 
 <aside class="notice">
-  In general, we would encourage customers to make use of the Embedded Job Application before going to the trouble of building their own form. Our application form is well tested, validated, battle hardened, and has built-in spam protection measures. Building your own form can introduce a number of challenges which are typically not worth the additional effort.
+  In general, we would encourage customers to make use of the Embedded Job Application before going to the trouble of building their own form. Our application form is well tested, validated, battle-hardened, and has built-in spam protection measures. Building your own form can introduce a number of challenges which are typically not worth the additional effort.
 </aside>
 
 ### HTTP Request
@@ -146,7 +146,7 @@ Parameter | Description
 *mapped_url_token | If present, the `gh_src` URL parameter, which is used to indicate the referral source of this application.
 first_name | Applicant's first name
 last_name | Applicant's last name
-email | Applicant's email adress
+email | Applicant's email address
 *phone | Applicant's phone number
 *location | Applicant's street address
 *latitude | Applicant's home latitude. This is a *hidden* field and should not be exposed directly to the applicant.

--- a/source/includes/job-board/_applications.md
+++ b/source/includes/job-board/_applications.md
@@ -64,7 +64,7 @@ curl -X POST \
   -F "question_12349_url_filename=attachment.pdf" \
   -F "question_12350_content=SGVsbG8sIHdvcmxkIQo=" \
   -F "question_12350_content_filename=something_else.txt" \
-  "https://api.greenhouse.io/v1/boards/very_awesome_inc/jobs/127817"
+  "https://api.greenhouse.io/v1/applications"
 ```
 
 > or, you can POST a JSON encoded body (with `Content-Type: application/json`):
@@ -113,7 +113,7 @@ curl -X POST \
     ],
     "mapped_url_token":"token12345"
   }' \
-  "https://api.greenhouse.io/v1/boards/very_awesome_inc/jobs/127817"
+  "https://api.greenhouse.io/v1/applications"
 ```
 
 Use this endpoint to submit a new application. This endpoint accepts a multipart form POST representing a job application. Application forms are job-specific and will be constructed via the "questions" array available via the [Job method](#retrieve-a-job). Please see the [Job method](#retrieve-a-job) documentation for instructions on submitting location information through the API.
@@ -130,14 +130,13 @@ Note that when submitting an application through this method, Greenhouse will no
 
 ### HTTP Request
 
-`POST https://api.greenhouse.io/v1/boards/{board_token}/jobs/{id}`
+`POST https://api.greenhouse.io/v1/applications`
 
-### URL Parameters
+### Request Headers
 
 Parameter | Description
 --------- | -----------
-board_token | Job Board URL token.  If you're submitting an application for a job post on an internal job board, use `"internal"`.
-id | Job post ID. Both internal and external job posts are allowed.
+Authorization | This header should include a basic authorization with a Base64 encoded API token
 
 ### Request Parameters
 


### PR DESCRIPTION
I've recently tried to implement the API job submission using the documentation but failed, since it didn't point out the correct URL and that the Authorization token needed to be base64 encoded.


Maybe it should be added a reference to the packages already developed for this? e.g. https://github.com/grnhse/greenhouse-tools-php