### PR TITLE
Green 13672 employee id in candidate hired webhook

### DIFF
--- a/source/includes/webhooks/_application_events.md
+++ b/source/includes/webhooks/_application_events.md
@@ -132,7 +132,8 @@
         "coordinator": {
           "id": 92427,
           "email": "user@example.com",
-          "name": "Bonnie Bonnet"
+          "name": "Bonnie Bonnet",
+          "employee_id": "456DEF"
         },
         "attachments": [
           {

--- a/source/includes/webhooks/_application_events.md
+++ b/source/includes/webhooks/_application_events.md
@@ -127,7 +127,8 @@
         "recruiter": {
           "id": 92120,
           "email": "employee@test.com",
-          "name": "Betty Smith"
+          "name": "Betty Smith",
+          "employee_id": "123ABC"
         },
         "coordinator": {
           "id": 92427,

--- a/source/includes/webhooks/_application_events.md
+++ b/source/includes/webhooks/_application_events.md
@@ -125,7 +125,7 @@
         ],
         "employments": [],
         "recruiter": {
-          "id": 92120,
+          "id": 92121,
           "email": "employee@test.com",
           "name": "Betty Smith",
           "employee_id": "123ABC"

--- a/source/includes/webhooks/_application_events.md
+++ b/source/includes/webhooks/_application_events.md
@@ -21,7 +21,8 @@
       "credited_to": {
         "id": 92120,
         "email": "test123@example.com",
-        "name": "Greenhouse Admin"
+        "name": "Greenhouse Admin",
+        "employee_id": "123ABC"
       },
       "rejection_reason": null,
       "rejection_details": null,
@@ -333,7 +334,8 @@ This web hook only fires when individual applications are destroyed.  This occur
       "credited_to": {
         "id": 3695,
         "email": "beauregard.blacksmith.3695@example.com",
-        "name": "Beauregard Blacksmith"
+        "name": "Beauregard Blacksmith",
+        "employee_id": "123ABC"
       },
       "rejection_reason": null,
       "rejection_details": null,

--- a/source/includes/webhooks/_candidate_events.md
+++ b/source/includes/webhooks/_candidate_events.md
@@ -116,7 +116,8 @@ This web hook will fire when a candidate or prospect is deleted from Greenhouse.
         "recruiter": {
           "id": 55,
           "email": "bob_johnson@localhost.com",
-          "name": "Bob Johnson"
+          "name": "Bob Johnson",
+          "employee_id": "456DEF"
         },
         "coordinator": {
           "id": 56,
@@ -449,7 +450,8 @@ This web hook will fire when a candidate or prospect is merged with another cand
         "recruiter": {
           "id": 3128,
           "email": "alicia.flopple.3128@example.com",
-          "name": "Alicia Flopple"
+          "name": "Alicia Flopple",
+          "employee_id": "789GHI"
         },
         "coordinator": {
           "id": 3128,
@@ -1047,7 +1049,8 @@ See web hook [common attributes](#common-attributes).
       "recruiter": {
         "id": 169779,
         "email": "hank.hollandaise.169779@example.com",
-        "name": "Hank Hollandaise"
+        "name": "Hank Hollandaise",
+        "employee_id": "123ABC"
       },
       "coordinator": {
         "id": 83637,
@@ -1172,7 +1175,8 @@ See web hook [common attributes](#common-attributes).
         "recruiter": {
           "id": 3128,
           "email": "alicia.flopple.3128@example.com",
-          "name": "Alicia Flopple"
+          "name": "Alicia Flopple",
+          "employee_id": "456DEF"
         },
         "coordinator": null,
         "attachments": [

--- a/source/includes/webhooks/_candidate_events.md
+++ b/source/includes/webhooks/_candidate_events.md
@@ -121,7 +121,8 @@ This web hook will fire when a candidate or prospect is deleted from Greenhouse.
         "coordinator": {
           "id": 56,
           "email": "bob_johnson_approver1@localhost.com",
-          "name": "Robert J Approver"
+          "name": "Robert J Approver",
+          "employee_id": "789GHI"
         },
         "attachments": [
           {
@@ -453,7 +454,8 @@ This web hook will fire when a candidate or prospect is merged with another cand
         "coordinator": {
           "id": 3128,
           "email": "alicia.flopple.3128@example.com",
-          "name": "Alicia Flopple"
+          "name": "Alicia Flopple",
+          "employee_id": "123ABC"
         },
         "attachments": [
           {
@@ -1050,7 +1052,8 @@ See web hook [common attributes](#common-attributes).
       "coordinator": {
         "id": 83637,
         "email": "sterling.kang.83637@example.com",
-        "name": "Sterling Kang"
+        "name": "Sterling Kang",
+        "employee_id": "456DEF"
       },
       "attachments": [
         {

--- a/source/includes/webhooks/_candidate_events.md
+++ b/source/includes/webhooks/_candidate_events.md
@@ -457,7 +457,7 @@ This web hook will fire when a candidate or prospect is merged with another cand
           "id": 3128,
           "email": "alicia.flopple.3128@example.com",
           "name": "Alicia Flopple",
-          "employee_id": "123ABC"
+          "employee_id": "789GHI"
         },
         "attachments": [
           {

--- a/source/includes/webhooks/_candidate_events.md
+++ b/source/includes/webhooks/_candidate_events.md
@@ -53,7 +53,8 @@ This web hook will fire when a candidate or prospect is deleted from Greenhouse.
       "credited_to": {
         "id": 158104,
         "email": "bob_johnson1@localhost.com",
-        "name": "Robert Johnson"
+        "name": "Robert Johnson",
+        "employee_id": "123ABC"
       },
       "source": {
         "id": 25,
@@ -351,7 +352,8 @@ This web hook will fire when a candidate or prospect is merged with another cand
       "credited_to": {
         "id": 15,
         "email": "ada@example.com",
-        "name": "Ada Lacey"
+        "name": "Ada Lacey",
+        "employee_id": "123ABC"
       },
       "rejection_reason": null,
       "rejection_details": null,
@@ -1108,7 +1110,8 @@ See web hook [common attributes](#common-attributes).
       "credited_to": {
         "id": 2622,
         "email": "carl.buddha.2622@example.com",
-        "name": "Carl Buddha"
+        "name": "Carl Buddha",
+        "employee_id": "123ABC"
       },
       "rejection_reason": null,
       "rejection_details": null,

--- a/source/includes/webhooks/_introduction.md
+++ b/source/includes/webhooks/_introduction.md
@@ -57,7 +57,7 @@ Currently, Web Hooks for all event types include these common attributes:
 | Attribute | Note |
 |-----------|------|
 | `application.id` | Unique Greenhouse identifier of the application. Information not included in the web hook can be retrieved via [Harvest API - GET Applications](/harvest.html#applications)
-| `application.credited_to` | If populated and a Greenhouse user, the user's Greenhouse ID and e-mail address will be provided. If populated and not a Greenhouse user, just the name will be provided.
+| `application.credited_to` | If populated and a Greenhouse user, the user's Greenhouse ID, e-mail address, and Employee ID (if available) will be provided. If populated and not a Greenhouse user, just the name will be provided.
 | `application.status` | One of: `rejected`, `hired`, `active`
 | `application.candidate.id` | Unique Greenhouse identifier of the candidate. Information not included in the web hook can be retrieved via [Harvest API - GET Candidates](/harvest.html#candidates)
 | `application.candidate.phone_numbers[].type` | One of: `home`, `work`, `mobile`, `skype`, `other`


### PR DESCRIPTION
https://greenhouseio.atlassian.net/browse/GREEN-14595

In addition to adding `employee_id` to the `credited_to` object, we also add it to `coordinator` and `recruiter`.