### PR TITLE
Upgrade json

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,4 +9,4 @@ gem 'rouge', '~> 1.9.0'
 gem 'redcarpet', '~> 3.3.2'
 
 gem 'rake', '~> 10.4.2'
-gem 'therubyracer', '~> 0.12.1', platforms: :ruby
+gem 'therubyracer', '~> 0.12', platforms: :ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,7 +39,7 @@ GEM
     hooks (0.4.0)
       uber (~> 0.0.4)
     i18n (0.7.0)
-    json (1.8.3)
+    json (1.8.6)
     kramdown (1.7.0)
     libv8 (3.16.14.19)
     listen (2.10.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,7 +98,7 @@ GEM
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
     redcarpet (3.3.2)
-    ref (1.0.5)
+    ref (2.0.0)
     rouge (1.9.0)
     sass (3.4.14)
     sprockets (2.12.3)
@@ -111,8 +111,8 @@ GEM
     sprockets-sass (1.3.1)
       sprockets (~> 2.0)
       tilt (~> 1.1)
-    therubyracer (0.12.2)
-      libv8 (~> 3.16.14.0)
+    therubyracer (0.12.3)
+      libv8 (~> 3.16.14.15)
       ref
     thor (0.19.1)
     thread_safe (0.3.5)
@@ -137,7 +137,7 @@ DEPENDENCIES
   rake (~> 10.4.2)
   redcarpet (~> 3.3.2)
   rouge (~> 1.9.0)
-  therubyracer (~> 0.12.1)
+  therubyracer (~> 0.12)
 
 BUNDLED WITH
-   1.16.1
+   1.17.3


### PR DESCRIPTION
Package upgrade to be compatible with Ruby 2.4.5.

- json: 1.8.3 -> 1.8.6
- rubyracer: 0.12.2 -> 0.12.3
- ref: 1.0.5 -> 2.0.0
- libv8: 3.16.14.0 -> 3.16.14.15
- bundler: 1.16.1 -> 1.17.3