### PR TITLE
Upgrading Ruby-image to fix error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5.1
+FROM ruby:2.7
 
 RUN apt-get update && apt-get install -y nodejs \
 && apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.7
+FROM ruby:2.6
 
 RUN apt-get update && apt-get install -y nodejs \
 && apt-get clean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Using the Ruby:2.5.1 image causes the following error:

Step 7/11 : RUN bundle install
 ---> Running in 2faa8f2f9af0
You must use Bundler 2 or greater with this lockfile.
The command '/bin/sh -c bundle install' returned a non-zero code: 20

Upgrading it to Ruby:2.6 makes it work properly.