### PR TITLE
Application missing `converted` status in noteworthy attributes section in docs

### DIFF
--- a/source/includes/harvest/_applications.md
+++ b/source/includes/harvest/_applications.md
@@ -107,7 +107,7 @@ Applications associate [candidates](#candidates) with [jobs](#jobs). There are 2
 |-----------|-------------|
 | id | Application ID |
 | prospect | If `true`, this is a prospect application which means that the associated person is a prospect and has not yet applied for this job.
-| status | One of: `active`, `rejected`, `hired`.
+| status | One of: `active`, `rejected`, `hired`, `converted`.
 | jobs | An array containing the [job](#jobs) that the candidate applied for.
 | candidate_id | The ID of the [candidate](#candidates) who is applying for this job.
 | current_stage | The current [stage](#job-stages) that this application is in.


### PR DESCRIPTION
Application can have a status of `converted`, as seen here:
![image](https://user-images.githubusercontent.com/18729755/104521699-41b73f00-55b2-11eb-8e5c-be6e56fc93a0.png)


However, the noteworthy attributes section is missing the `converted` status:
![image](https://user-images.githubusercontent.com/18729755/104521744-5b588680-55b2-11eb-8c79-53f344f8046b.png)
