### PR TITLE
[GREEN-30828] - bug fixed typo on applications page

### DIFF
--- a/source/includes/harvest/_applications.md
+++ b/source/includes/harvest/_applications.md
@@ -118,8 +118,8 @@ Applications associate [candidates](#candidates) with [jobs](#jobs). There are 2
 | answers | The answers provided to the questions in the job post for this application. Array contains the text value of the question and answer. Answers are always plaintext strings. Booleans will return `Yes` or `No`.
 | custom_fields | Contains a hash of the custom fields configured for this resource. The properties in this hash reflect the active custom fields as of the time this method is called.
 | keyed_custom_fields | This contains the same information as custom_fields but formatted in a different way that includes more information.  This will tell you the type of custom field data to expect, the text name of custom field, and the value.  The key of this hash is the custom field's immutable field key, which will not change even if the name of the custom field is changed in Greenhouse.
-| prospective_office | The [department](#the-department-object) that this prospect application is being considered for. |
-| prospective_department | The [office](#the-office-object) that this prospect application is being considered for. |
+| prospective_department | The [department](#the-department-object) that this prospect application is being considered for. |
+| prospective_office | The [office](#the-office-object) that this prospect application is being considered for. |
 
 
 ## GET: List Applications


### PR DESCRIPTION
fixed typo for prospective_department and prospective_office having the wrong definitions assigned to them

[GREEN-30828](https://greenhouseio.atlassian.net/browse/GREEN-30828)