### PR TITLE
fix: change type of prospect field in prospect application

### DIFF
--- a/source/includes/harvest/_applications.md
+++ b/source/includes/harvest/_applications.md
@@ -581,7 +581,7 @@ attachments | No | array | An array of attachments to be uploaded to this applic
 
 Parameter | Required | Type | Description
 --------- | ----------- | ----------- | ----------- |
-prospect | Yes | boolean | Set to `"true"` in order to create a prospect application.
+prospect | Yes | string | Set to `"true"` in order to create a prospect application.
 job_ids | No | array | An optional array of Job IDs to consider this prospect for.
 source_id | No | integer | The id of the source to be credited for this application
 referrer | No | object | An object representing the referrer


### PR DESCRIPTION
<!--- Thanks for contributing -->

I changed the type of the `prospect` field in the `Create a new application for an existing candidate or prospect.` [endpoint](https://developers.greenhouse.io/harvest.html#post-add-application-to-candidate-prospect), it was a boolean, but the description is referring to `"true"` which is confusing

When using `"prospect": true` as a boolean value I kept getting a `201 Created` which wouldn't add the application on my prospect. After further investigation I realized the server responded with a body of 

```json
{
  "errors": [
    {
      "message": "Not found"
    }
  ]
}
```
which was really confusing.

By switching to `"prospect": "true"` I was able to make everything work.

Like [others](https://github.com/grnhse/greenhouse-api-docs/issues/459) I expected to be able to add the prospect pool and prospect pool stage when creating a prospect 

<!---
If you updated the Harvest API, Assessment API, or Candidate Ingestion API, don't forget to also update the changelog

Harvest: https://github.com/grnhse/greenhouse-api-docs/blob/master/source/includes/harvest/_introduction.md?plain=1#L173
Assessment: https://github.com/grnhse/greenhouse-api-docs/blob/master/source/includes/assessment/_introduction.md?plain=1#L73
Candidate Ingestion: https://github.com/grnhse/greenhouse-api-docs/blob/master/source/includes/candidate-ingestion/_introduction.md?plain=1#L115
-->
