### PR TITLE
GREEN-45026 Update assessment API docs for active, unhired candidates

### DIFF
--- a/source/includes/assessment/_introduction.md
+++ b/source/includes/assessment/_introduction.md
@@ -32,9 +32,11 @@ When a candidate reaches this Interview Stage, the user will click the "Send Tes
 
 ### Receiving the Test Results
 
-Greenhouse will periodically poll the [Test Status endpoint](#test-status) to retrieve the candidate's test status and results. When the candidate completes the test, Greenhouse will notify the appropriate user that the test is complete. The user will be able to view the candidate’s score, navigate to the partner site to see more details, and make an advance or reject decision within Greenhouse. The user will also be able to filter candidates by score and advance or reject candidates in bulk.
+Greenhouse will periodically poll the [Test Status endpoint](#test-status) to retrieve the candidate's test status and results. When the candidate completes the test, Greenhouse will notify the appropriate user that the test is complete. The user will be able to view the candidate's score, navigate to the partner site to see more details, and make an advance or reject decision within Greenhouse. The user will also be able to filter candidates by score and advance or reject candidates in bulk.
 
-Alternatively, Greenhouse's Assessment API now includes the ability to notify Greenhouse of completed tests via the [PATCH - Mark Test as Completed](#patch-mark-test-as-completed) endpoint to avoid long polling!
+Alternatively, Greenhouse's Assessment API now includes the ability to notify Greenhouse of completed tests via the [PATCH - Mark Test as Completed endpoint](#patch-mark-test-as-completed) to avoid long polling!
+
+**Note**: You can only update test statuses for active, unhired candidates.
 
 ## Authentication
 
@@ -71,9 +73,10 @@ Unless otherwise specified, API methods generally conform to the following:
 
 The timestamps below are Eastern Time.
 
-| Date                   | Description                                                                             |
-| ---------------------- | --------------------------------------------------------------------------------------- |
-| Oct 13, 2023 3:00:00PM | Added URL for `response_error` as a requirement in [Introduction](#introduction)        |
-| Aug 22, 2023 3:00:00PM | Fixed URL expiry timing in [Send Test](#send-test)                                      |
-| Aug 21, 2019 2:00:00PM | Added Change Log and General Consideration sections to the Assessment API documentation |
-| Aug 21, 2019 2:00:00PM | Added [PATCH - Mark Test as Completed](#patch-mark-test-as-completed) endpoint          |
+| Date                    | Description																																																											|
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| Oct 19, 2023 12:30:00PM | Clarified use of Assessment API for active, unhired candidates in [Introduction](#introduction) and [Test Status](#test-status)	|
+| Oct 13, 2023 3:00:00PM  | Added URL for `response_error` as a requirement in [Introduction](#introduction)        																					|
+| Aug 22, 2023 3:00:00PM  | Fixed URL expiry timing in [Send Test](#send-test)                                      																					|
+| Aug 21, 2019 2:00:00PM  | Added Change Log and General Consideration sections to the Assessment API documentation 																					|
+| Aug 21, 2019 2:00:00PM  | Added [PATCH - Mark Test as Completed](#patch-mark-test-as-completed) endpoint          																					|

--- a/source/includes/assessment/_test_status.md
+++ b/source/includes/assessment/_test_status.md
@@ -2,11 +2,11 @@
 
 ### If you have implemented the polling option:
 <aside class="warning">The polling option has been deprecated as of October 1, 2019. All Assessment API implementations after this date must use the PATCH Completed Test endpoint. However, existing integrations will continue to work with the original test status method.</aside>
-After a successful `send_test` request, Greenhouse will check whether the test instance has been completed by polling the `test_status` endpoint hourly. We will discontinue polling the `test_status` endpoint after we receive a `partner_status` of `complete`, or after 8 weeks has passed since the test was sent.
+After a successful `send_test` request, Greenhouse will check whether the test instance has been completed by polling the `test_status` endpoint hourly. We will discontinue polling the `test_status` endpoint after the candidate is marked as hired, after we receive a `partner_status` of `complete`, or after 8 weeks have passed since the test was sent.
 
 ### If you have implemented the PATCH Completed Test option:
 
-After a successful `send_test` request, you can alert Greenhouse to updates of the test's status by sending a [PATCH Completed Test](#patch-mark-test-as-completed) request to the URL found in the `url` field of the `send_test` request. This will trigger a <a href="#test-status">Test Status</a> request from Greenhouse.
+After a successful `send_test` request, you can alert Greenhouse to updates of the test's status by sending a [PATCH Completed Test](#patch-mark-test-as-completed) request to the URL found in the `url` field of the `send_test` request. This will trigger a [Test Status](#test-status) request from Greenhouse. Active, unhired candidates will show the completed test status.
 
 # Test Status
 


### PR DESCRIPTION
[GREEN-45026]

<!--- Thanks for contributing -->

<!---
If you updated the Harvest API, Assessment API, or Candidate Ingestion API, don't forget to also update the changelog

Harvest: https://github.com/grnhse/greenhouse-api-docs/blob/master/source/includes/harvest/_introduction.md?plain=1#L173
Assessment: https://github.com/grnhse/greenhouse-api-docs/blob/master/source/includes/assessment/_introduction.md?plain=1#L73
Candidate Ingestion: https://github.com/grnhse/greenhouse-api-docs/blob/master/source/includes/candidate-ingestion/_introduction.md?plain=1#L115
-->


[GREEN-45026]: https://greenhouseio.atlassian.net/browse/GREEN-45026?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ