### PR TITLE
GREEN-52125: Update webhook retry policy

### DIFF
--- a/source/includes/webhooks/_introduction.md
+++ b/source/includes/webhooks/_introduction.md
@@ -188,30 +188,16 @@ If a webhook is disabled, it will not trigger when the event occurs. Webhooks be
 
 ## Retry policy
 
-In the event of a failed webhook request (due to timeout, a non HTTP 200 response, or network issues), Greenhouse will make up to 6 attempts according to the formula on the right.
+In the event of a failed webhook request (due to timeout, a non HTTP 200 response, or network issues), Greenhouse will make up to 6 attempts over the course of 7 hours.
 
-This formula increases the amount of time between each retry, while assigning a random number of seconds to avoid consistent failures from overload or contention.
 
-Greenhouse will make up to 6 attempts over the course of 7 hours.
+The table below outlines the estimated wait time for each attempt.
 
-```ruby
-RETRY_DELAY_MINUTES = [0, 1, 15, 60, 120, 240]
-
-sidekiq_retry_in do |index, _exception|
-  seconds_delay = (RETRY_DELAY_MINUTES[index] || RETRY_DELAY_MINUTES.last) * 60
-  offset = rand(30) * (index + 1)
-
-  seconds_delay + offset
-end
-```
-
-The table below outlines the estimated wait time for each attempt, assuming that rand(30) always returns 0.
-
-| Attempt number | Next Attempt in | Total waiting time  |
-| -------------- | --------------- | ------------------  |
-|       1        |        1m       |            0m       |
-|       2        |       15m       |        0h  1m       |
-|       3        |       60m       |        0h 16m       |
-|       4        |      120m       |        1h 16m       |
-|       5        |      240m       |        3h 16m       |
-|       6        |        --       |        7h 16m       |
+| Approx. Total waiting time | Attempt number | Next Attempt in |
+| :--------------------------: | :--------------: | :---------------: |
+|           0h  0m           |       1        |        1m       |
+|           0h  1m           |       2        |       15m       |
+|           0h 16m           |       3        |       60m       |
+|           1h 16m           |       4        |      120m       |
+|           3h 16m           |       5        |      240m       |
+|           7h 16m           |       6        |        --       |

--- a/source/includes/webhooks/_introduction.md
+++ b/source/includes/webhooks/_introduction.md
@@ -188,14 +188,14 @@ If a webhook is disabled, it will not trigger when the event occurs. Webhooks be
 
 ## Retry policy
 
-In the event of a failed webhook request (due to timeout, a non HTTP 200 response, or network issues), Greenhouse will attempt a maximum of 6 retries according to the formula on the right:
+In the event of a failed webhook request (due to timeout, a non HTTP 200 response, or network issues), Greenhouse will make up to 6 attempts according to the formula on the right.
 
 This formula increases the amount of time between each retry, while assigning a random number of seconds to avoid consistent failures from overload or contention.
 
-Greenhouse will attempt 6 retries over the course of 15 hours.
+Greenhouse will make up to 6 attempts over the course of 7 hours.
 
 ```ruby
-RETRY_DELAY_MINUTES = [1, 15, 60, 120, 240, 480]
+RETRY_DELAY_MINUTES = [0, 1, 15, 60, 120, 240]
 
 sidekiq_retry_in do |index, _exception|
   seconds_delay = (RETRY_DELAY_MINUTES[index] || RETRY_DELAY_MINUTES.last) * 60
@@ -205,13 +205,13 @@ sidekiq_retry_in do |index, _exception|
 end
 ```
 
-The table below outlines the estimated wait time for each retry request, assuming that rand(30) always returns 0.
+The table below outlines the estimated wait time for each attempt, assuming that rand(30) always returns 0.
 
-| Retry number | Next Retry in | Total waiting time |
-| ------------ | ------------- | ------------------ |
-|       1      |        1m     |        0h  1m      |
-|       2      |       15m     |        0h 16m      |
-|       3      |       60m     |        1h 16m      |
-|       4      |      120m     |        3h 16m      |
-|       5      |      240m     |        7h 16m      |
-|       6      |      480m     |       15h 16m      |
+| Attempt number | Next Attempt in | Total waiting time  |
+| -------------- | --------------- | ------------------  |
+|       1        |        1m       |            0m       |
+|       2        |       15m       |        0h  1m       |
+|       3        |       60m       |        0h 16m       |
+|       4        |      120m       |        1h 16m       |
+|       5        |      240m       |        3h 16m       |
+|       6        |        --       |        7h 16m       |

--- a/source/includes/webhooks/_introduction.md
+++ b/source/includes/webhooks/_introduction.md
@@ -188,16 +188,17 @@ If a webhook is disabled, it will not trigger when the event occurs. Webhooks be
 
 ## Retry policy
 
-In the event of a failed webhook request (due to timeout, a non HTTP 200 response, or network issues), Greenhouse will make up to 6 attempts over the course of 7 hours.
+In the event of a failed webhook request (due to timeout, a non HTTP 200 response, or network issues), Greenhouse will make up to 7 attempts over the course of 15 hours.
 
 
 The table below outlines the estimated wait time for each attempt.
 
 | Approx. Total waiting time | Attempt number | Next Attempt in |
-| :--------------------------: | :--------------: | :---------------: |
-|           0h  0m           |       1        |        1m       |
-|           0h  1m           |       2        |       15m       |
-|           0h 16m           |       3        |       60m       |
-|           1h 16m           |       4        |      120m       |
-|           3h 16m           |       5        |      240m       |
-|           7h 16m           |       6        |        --       |
+| :-------------------------- | :--------------: | :--------------- |
+|           0h  0m           |       1        |         1m       |
+|           0h  1m           |       2        |         15m       |
+|           0h 16m           |       3        |         60m       |
+|           1h 16m           |       4        |         120m       |
+|           3h 16m           |       5        |         240m       |
+|           7h 16m           |       6        |         480m       |
+|          15h 16m           |       7        |          --       |


### PR DESCRIPTION
https://greenhouseio.atlassian.net/browse/GREEN-52125

<!--- Thanks for contributing -->

<!---
If you updated the Harvest API, Assessment API, or Candidate Ingestion API, don't forget to also update the changelog

Harvest: https://github.com/grnhse/greenhouse-api-docs/blob/master/source/includes/harvest/_introduction.md?plain=1#L173
Assessment: https://github.com/grnhse/greenhouse-api-docs/blob/master/source/includes/assessment/_introduction.md?plain=1#L73
Candidate Ingestion: https://github.com/grnhse/greenhouse-api-docs/blob/master/source/includes/candidate-ingestion/_introduction.md?plain=1#L115
-->
