### PR TITLE
[GREEN-53503] Update Job Board API docs to include `gdpr_demographic_data_consent_given` field

### DIFF
--- a/source/includes/job-board/_applications.md
+++ b/source/includes/job-board/_applications.md
@@ -41,6 +41,10 @@ Please keep in mind that the HTTP Basic Auth API token is a secret key.  Any for
     {{ORGANIZATION}} has my consent to collect, store, and process my data for the purpose
     of considering me for employment.
   </label>
+  <label>
+    <input type="checkbox" name="data_compliance[gdpr_demographic_data_consent_given]" value="1" />
+    By checking this box, I consent to {{ORGANIZATION}} collecting, storing, and processing my responses to the demographic data surveys above.
+  </label>
   <input type="submit" />
 </form>
 ```
@@ -87,6 +91,7 @@ curl -X POST \
   -F "data_compliance[gdpr_consent_given]=true" \ # `gdpr_consent_given` to be deprecated. Use if your organization doesn't have single-purpose consent configured, otherwise use separate values for processing and retention
   -F "data_compliance[gdpr_processing_consent_given]=true" \
   -F "data_compliance[gdpr_retention_consent_given]=true" \
+  -F "data_compliance[gdpr_demographic_data_consent_given]=true" \
   "https://boards-api.greenhouse.io/v1/boards/very_awesome_inc/jobs/127817"
 ```
 
@@ -174,6 +179,7 @@ curl -X POST \
     "gdpr_consent_given": true, // To be deprecated. Use if your organization doesn't have single-purpose consent configured, otherwise use separate values for processing and retention
     "gdpr_processing_consent_given": true
     "gdpr_retention_consent_given": true
+    "gdpr_demographic_data_consent_given": true
   }' \
   "https://boards-api.greenhouse.io/v1/boards/very_awesome_inc/jobs/127817"
 ```

--- a/source/includes/job-board/_jobs.md
+++ b/source/includes/job-board/_jobs.md
@@ -321,7 +321,7 @@ For organizations using Greenhouse Inclusion, the response may contain demograph
 
 ### Data Compliance
 
-For organizations with GDPR rules configured and operating with a legal basis of explicit consent, the response may contain data_compliance objects. These objects will include whether a response is required and the data retention period in days as configured by the appropriate rule.
+Responses may include `data_compliance` objects if your organization is using GDPR rules and 'explicit consent' legal basis. The object includes whether a response is required, and configured data retention period (in days) for the associated rule.
 
 ### Board-level Introductions and Conclusions
 


### PR DESCRIPTION
<!--- Thanks for contributing -->

<!---
If you updated the Harvest API, Assessment API, or Candidate Ingestion API, don't forget to also update the changelog

Harvest: https://github.com/grnhse/greenhouse-api-docs/blob/master/source/includes/harvest/_introduction.md?plain=1#L173
Assessment: https://github.com/grnhse/greenhouse-api-docs/blob/master/source/includes/assessment/_introduction.md?plain=1#L73
Candidate Ingestion: https://github.com/grnhse/greenhouse-api-docs/blob/master/source/includes/candidate-ingestion/_introduction.md?plain=1#L115
-->
