### PR TITLE
📝 GREEN-61470: Add banner for harvest docs to link to new v3 documentation

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -126,6 +126,11 @@ under the License.
       <% end %>
     </div>
     <div class="page-wrapper">
+      <% if current_page.data.slug == 'harvest' %>
+      <div class="service-banner harvest-banner">
+        <span>Visit the latest version of Harvest API at <a href="https://harvestdocs.greenhouse.io" target="_blank" rel="noopener">harvestdocs.greenhouse.io</a>.</span>
+      </div>
+      <% end %>
       <div class="dark-box"></div>
       <div class="content">
         <%= page_content %>

--- a/source/stylesheets/screen_harvest.css.scss
+++ b/source/stylesheets/screen_harvest.css.scss
@@ -4,4 +4,58 @@
 $nav-subitem-bg: $harvest-base;
 $nav-active-parent-bg: $harvest-hover;
 
+// Top banner specific to Harvest
+$harvest-banner-height: 44px;
+
+.service-banner.harvest-banner {
+  background: $harvest-base;
+  color: $birch-white;
+  position: sticky;
+  top: 0;
+  z-index: 60; // above toc (30) and lang selector (50)
+  height: $harvest-banner-height;
+  line-height: $harvest-banner-height;
+  padding: 0 15px;
+  font-weight: bold;
+
+  a:link,
+  a:visited,
+  a:active {
+    color: $birch-white;
+    text-decoration: underline;
+  }
+}
+
+// Ensure the language selector sits below the sticky banner
+.page-wrapper .lang-selector {
+  top: $harvest-banner-height;
+}
+
+@media (max-width: $tablet-width) {}
+
+@media (max-width: $phone-width) {
+
+  // Lang selector is hidden on phone width; give extra space for the banner just in case
+  // no extra padding needed; sticky banner does not overlap content
+}
+
+// Ensure anchor jumps don’t hide headings under fixed banner
+.content {
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    scroll-margin-top: $harvest-banner-height + 10px;
+  }
+}
+
+// Legacy fallback for browsers without scroll-margin-top
+// Adds temporary spacing when a heading is targeted
+:target {
+  scroll-margin-top: $harvest-banner-height + 10px;
+}
+
 @import "screen";


### PR DESCRIPTION
<!--- Thanks for contributing -->

<!---
If you updated the Harvest API, Assessment API, or Candidate Ingestion API, don't forget to also update the changelog

Harvest: https://github.com/grnhse/greenhouse-api-docs/blob/master/source/includes/harvest/_introduction.md?plain=1#L173
Assessment: https://github.com/grnhse/greenhouse-api-docs/blob/master/source/includes/assessment/_introduction.md?plain=1#L73
Candidate Ingestion: https://github.com/grnhse/greenhouse-api-docs/blob/master/source/includes/candidate-ingestion/_introduction.md?plain=1#L115
-->
