### PR TITLE
💄 GREEN-66348: Update Harvest deprecation banner with warning style and date

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -128,7 +128,7 @@ under the License.
     <div class="page-wrapper">
       <% if current_page.data.slug == 'harvest' %>
       <div class="service-banner harvest-banner">
-        <span>⚠️ The Harvest v1/v2 API will be deprecated on August 31, 2026. Please migrate to <a href="https://harvestdocs.greenhouse.io" target="_blank" rel="noopener">Harvest v3</a>.</span>
+        <span>⚠️ The Harvest v1/v2 API is deprecated and will be removed on August 31, 2026. Please migrate to <a href="https://harvestdocs.greenhouse.io" target="_blank" rel="noopener">Harvest v3</a>.</span>
       </div>
       <% end %>
       <div class="dark-box"></div>

--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -128,7 +128,7 @@ under the License.
     <div class="page-wrapper">
       <% if current_page.data.slug == 'harvest' %>
       <div class="service-banner harvest-banner">
-        <span>Visit the latest version of Harvest API at <a href="https://harvestdocs.greenhouse.io" target="_blank" rel="noopener">harvestdocs.greenhouse.io</a>.</span>
+        <span>⚠️ The Harvest v1/v2 API will be deprecated on August 31, 2026. Please migrate to <a href="https://harvestdocs.greenhouse.io" target="_blank" rel="noopener">Harvest v3</a>.</span>
       </div>
       <% end %>
       <div class="dark-box"></div>

--- a/source/stylesheets/screen_harvest.css.scss
+++ b/source/stylesheets/screen_harvest.css.scss
@@ -8,7 +8,7 @@ $nav-active-parent-bg: $harvest-hover;
 $harvest-banner-height: 44px;
 
 .service-banner.harvest-banner {
-  background: $harvest-base;
+  background: $birch-poppy-600;
   color: $birch-white;
   position: sticky;
   top: 0;


### PR DESCRIPTION
## Context & Purpose

The current Harvest API deprecation banner on developers.greenhouse.io is too subtle (green, soft language). Partners are still building new integrations on v1/v2 despite the banner. This updates the banner to use a red warning color and explicitly states the August 31, 2026 deprecation date.

[GREEN-66348](https://greenhouseio.atlassian.net/browse/GREEN-66348)

## How to Test

- [x] `bundle exec middleman build` — verify site builds without errors
- [x] Open built `harvest.html` — confirm banner is red (`#D8372A`) with text: "⚠️ The Harvest v1/v2 API will be deprecated on August 31, 2026. Please migrate to Harvest v3."
- [x] Verify the link points to https://harvestdocs.greenhouse.io

[GREEN-66348]: https://greenhouseio.atlassian.net/browse/GREEN-66348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ