### PR TITLE
Include candidate id and application id in send_test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,90 +1,20 @@
-<p align="center">
-  <img src="https://raw.githubusercontent.com/slatedocs/img/main/logo-slate.png" alt="Slate: API Documentation Generator" width="226">
-  <br>
-  <a href="https://github.com/slatedocs/slate/actions?query=workflow%3ABuild+branch%3Amain"><img src="https://github.com/slatedocs/slate/workflows/Build/badge.svg?branch=main" alt="Build Status"></a>
-  <a href="https://hub.docker.com/r/slatedocs/slate"><img src="https://img.shields.io/docker/v/slatedocs/slate?sort=semver" alt="Docker Version" /></a>
-</p>
-
-<p align="center">Slate helps you create beautiful, intelligent, responsive API documentation.</p>
-
-<p align="center"><img src="https://raw.githubusercontent.com/slatedocs/img/main/screenshot-slate.png" width=700 alt="Screenshot of Example Documentation created with Slate"></p>
-
-<p align="center"><em>The example above was created with Slate. Check it out at <a href="https://slatedocs.github.io/slate">slatedocs.github.io/slate</a>.</em></p>
-
-Features
-------------
-
-* **Clean, intuitive design** — With Slate, the description of your API is on the left side of your documentation, and all the code examples are on the right side. Inspired by [Stripe's](https://stripe.com/docs/api) and [PayPal's](https://developer.paypal.com/webapps/developer/docs/api/) API docs. Slate is responsive, so it looks great on tablets, phones, and even in print.
-
-* **Everything on a single page** — Gone are the days when your users had to search through a million pages to find what they wanted. Slate puts the entire documentation on a single page. We haven't sacrificed linkability, though. As you scroll, your browser's hash will update to the nearest header, so linking to a particular point in the documentation is still natural and easy.
-
-* **Slate is just Markdown** — When you write docs with Slate, you're just writing Markdown, which makes it simple to edit and understand. Everything is written in Markdown — even the code samples are just Markdown code blocks.
-
-* **Write code samples in multiple languages** — If your API has bindings in multiple programming languages, you can easily put in tabs to switch between them. In your document, you'll distinguish different languages by specifying the language name at the top of each code block, just like with GitHub Flavored Markdown.
-
-* **Out-of-the-box syntax highlighting** for [over 100 languages](https://github.com/rouge-ruby/rouge/wiki/List-of-supported-languages-and-lexers), no configuration required.
-
-* **Automatic, smoothly scrolling table of contents** on the far left of the page. As you scroll, it displays your current position in the document. It's fast, too. We're using Slate at TripIt to build documentation for our new API, where our table of contents has over 180 entries. We've made sure that the performance remains excellent, even for larger documents.
-
-* **Let your users update your documentation for you** — By default, your Slate-generated documentation is hosted in a public GitHub repository. Not only does this mean you get free hosting for your docs with GitHub Pages, but it also makes it simple for other developers to make pull requests to your docs if they find typos or other problems. Of course, if you don't want to use GitHub, you're also welcome to host your docs elsewhere.
-
-* **RTL Support** Full right-to-left layout for RTL languages such as Arabic, Persian (Farsi), Hebrew etc.
-
-Getting started with Slate is super easy! Simply press the green "use this template" button above and follow the instructions below. Or, if you'd like to check out what Slate is capable of, take a look at the [sample docs](https://slatedocs.github.io/slate/).
-
-Getting Started with Slate
+Getting Started
 ------------------------------
 
-To get started with Slate, please check out the [Getting Started](https://github.com/slatedocs/slate/wiki#getting-started)
-section in our [wiki](https://github.com/slatedocs/slate/wiki).
+This project was started from a Slate template (<a href="https://slatedocs.github.io/slate">slatedocs.github.io/slate</a>).
 
-We support running Slate in three different ways:
-* [Natively](https://github.com/slatedocs/slate/wiki/Using-Slate-Natively)
-* [Using Vagrant](https://github.com/slatedocs/slate/wiki/Using-Slate-in-Vagrant)
-* [Using Docker](https://github.com/slatedocs/slate/wiki/Using-Slate-in-Docker)
+Quick start:
+```bash
+bundle install
+bundle exec middleman server
+```
 
+For more in depth documentation, check the [Slate wiki](https://github.com/slatedocs/slate/wiki).
 
 Releasing
 ---------------------------------
 
-1. Merge your branch to master
-2. Run `bundle exec rake publish` - this will build & push to the `gh-pages` branch
-3. Validate the changes are up on `https://developers.greenhouse.io/` - sometimes there is a few minutes lag
-
-Companies Using Slate
----------------------------------
-
-* [NASA](https://api.nasa.gov)
-* [Sony](http://developers.cimediacloud.com)
-* [Best Buy](https://bestbuyapis.github.io/api-documentation/)
-* [Travis-CI](https://docs.travis-ci.com/api/)
-* [Greenhouse](https://developers.greenhouse.io/harvest.html)
-* [WooCommerce](http://woocommerce.github.io/woocommerce-rest-api-docs/)
-* [Dwolla](https://docs.dwolla.com/)
-* [Clearbit](https://clearbit.com/docs)
-* [Coinbase](https://developers.coinbase.com/api)
-* [Parrot Drones](http://developer.parrot.com/docs/bebop/)
-* [CoinAPI](https://docs.coinapi.io/)
-
-You can view more in [the list on the wiki](https://github.com/slatedocs/slate/wiki/Slate-in-the-Wild).
-
-Questions? Need Help? Found a bug?
---------------------
-
-If you've got questions about setup, deploying, special feature implementation in your fork, or just want to chat with the developer, please feel free to [start a thread in our Discussions tab](https://github.com/slatedocs/slate/discussions)!
-
-Found a bug with upstream Slate? Go ahead and [submit an issue](https://github.com/slatedocs/slate/issues). And, of course, feel free to submit pull requests with bug fixes or changes to the `dev` branch.
-
-Contributors
---------------------
-
-Slate was built by [Robert Lord](https://lord.io) while at [TripIt](https://www.tripit.com/). The project is now maintained by [Matthew Peveler](https://github.com/MasterOdin) and [Mike Ralphson](https://github.com/MikeRalphson).
-
-Thanks to the following people who have submitted major pull requests:
-
-- [@chrissrogers](https://github.com/chrissrogers)
-- [@bootstraponline](https://github.com/bootstraponline)
-- [@realityking](https://github.com/realityking)
-- [@cvkef](https://github.com/cvkef)
-
-Also, thanks to [Sauce Labs](http://saucelabs.com) for sponsoring the development of the responsive styles.
+1. Create a PR - make sure to open against the Greenhouse github repository
+2. Get a review and merge your branch
+3. Run `bundle exec rake publish` - this will build & push to the `gh-pages` branch
+4. Validate the changes are up on `https://developers.greenhouse.io/` - sometimes there is a few minutes lag

--- a/source/includes/assessment/_introduction.md
+++ b/source/includes/assessment/_introduction.md
@@ -77,7 +77,8 @@ The timestamps below are Eastern Time.
 
 | Date                    | Description                                                                                                                     |
 | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------- | --- |
-| Jan 10, 2025            | Updated send test response to include preferred name column                                                                     |
+| Jul 30, 2025            | Added candidate and application id to [Send Test](#send-test)                                                                     |
+| Jan 10, 2025            | Updated send test request body to include preferred name column                                                                     |
 | Oct 7, 2024             | Updated favicon, github mark, and color palette. Fixed typos and formatting errors.                                             |
 | Oct 4, 2024 3:30:00PM   | Updated guidelines around API key character length in [Introduction](#introduction)                                             |
 | Sep 18, 2024 10:45:00AM | Added `sent_by` to the [Send Test](#send-test) request example                                                                  |     |

--- a/source/includes/assessment/_send_test.md
+++ b/source/includes/assessment/_send_test.md
@@ -19,7 +19,11 @@ curl -X POST 'https://www.testing-partner.com/api/send_test'
     "resume_url": "https://hogwarts.com/resume",
     "phone_number": "123-456-7890",
     "email": "hpotter@hogwarts.edu",
-    "greenhouse_profile_url": "https://app.greenhouse.io/people/17681532?application_id=26234709"
+    "greenhouse_profile_url": "https://app.greenhouse.io/people/17681532?application_id=26234709",
+    "id": 4000024002
+  },
+  "application": {
+    "id": 4000027002
   },
   "sent_by": "test_sender@example.org",
   "url": "https://app.greenhouse.io/integrations/testing_partners/take_home_tests/12345"
@@ -28,18 +32,20 @@ curl -X POST 'https://www.testing-partner.com/api/send_test'
 
 Greenhouse will initiate the process by sending a POST request to the `send_test` endpoint specified by the Assessment Partner. The body of the POST request will contain a JSON payload.
 
-| Property Name          | Type   | Required | Description                                                                                                                |
-| ---------------------- | ------ | -------- | -------------------------------------------------------------------------------------------------------------------------- |
-| partner_test_id        | String | Yes      | Identifies a test available to an organization. Initially provided as a response to the [List Tests request](#list-tests). |
-| first_name             | String | Yes      | The first name of the candidate.                                                                                           |
-| last_name              | String | Yes      | The last name of the candidate.                                                                                            |
-| preferred_name         | String | Yes      | The preferred name of the candidate.                                                                                       |
-| resume_url             | String | No       | A URL to the candidate’s resume. This URL will expire 7 days after the request.                                            |
-| phone_number           | String | No       | The candidate’s phone number.                                                                                              |
-| email                  | String | Yes      | The candidate’s email address. The test should be sent to this address.                                                    |
-| greenhouse_profile_url | String | Yes      | URL to the candidate’s Greenhouse application. Allows the partner to link back to Greenhouse.                              |
-| sent_by                | String | No       | Test sender's email address                                                                                                |
-| url                    | String | Yes      | URL to which to send the [PATCH Completed Test](#patch-mark-test-as-completed) request, if using                           |
+| Property Name                    | Type   | Required | Description                                                                                                                |
+|----------------------------------|--------|----------|----------------------------------------------------------------------------------------------------------------------------|
+| partner_test_id                  | String | Yes      | Identifies a test available to an organization. Initially provided as a response to the [List Tests request](#list-tests). |
+| candidate.first_name             | String | Yes      | The first name of the candidate.                                                                                           |
+| candidate.last_name              | String | Yes      | The last name of the candidate.                                                                                            |
+| candidate.preferred_name         | String | Yes      | The preferred name of the candidate.                                                                                       |
+| candidate.resume_url             | String | No       | A URL to the candidate’s resume. This URL will expire 7 days after the request.                                            |
+| candidate.phone_number           | String | No       | The candidate’s phone number.                                                                                              |
+| candidate.email                  | String | Yes      | The candidate’s email address. The test should be sent to this address.                                                    |
+| candidate.greenhouse_profile_url | String | Yes      | URL to the candidate’s Greenhouse application. Allows the partner to link back to Greenhouse.                              |
+| candidate.id                     | Number | Yes      | Id of the candidate                                                                                                        |
+| application.id                   | String | Yes      | Id of the application                                                                                                      |
+| sent_by                          | String | No       | Test sender's email address                                                                                                |
+| url                              | String | Yes      | URL to which to send the [PATCH Completed Test](#patch-mark-test-as-completed) request, if using                           |
 
 ### Response
 


### PR DESCRIPTION
I added documentation for the newly added ids in send_test. I also ripped out the irrelevant parts to the README and made the getting started more clear.

<!--- Thanks for contributing -->

<!---
If you updated the Harvest API, Assessment API, or Candidate Ingestion API, don't forget to also update the changelog

Harvest: https://github.com/grnhse/greenhouse-api-docs/blob/master/source/includes/harvest/_introduction.md?plain=1#L173
Assessment: https://github.com/grnhse/greenhouse-api-docs/blob/master/source/includes/assessment/_introduction.md?plain=1#L73
Candidate Ingestion: https://github.com/grnhse/greenhouse-api-docs/blob/master/source/includes/candidate-ingestion/_introduction.md?plain=1#L115
-->
